### PR TITLE
BATCHIMP-26: DBList property values are not always imported correctly

### DIFF
--- a/xwiki-batchimport-postprocessors/dblistidentifier/src/main/java/org/xwiki/batchimport/postprocessors/DBListIdentifierPostprocessor.java
+++ b/xwiki-batchimport-postprocessors/dblistidentifier/src/main/java/org/xwiki/batchimport/postprocessors/DBListIdentifierPostprocessor.java
@@ -46,6 +46,7 @@ import com.xpn.xwiki.objects.classes.DBListClass;
 import com.xpn.xwiki.objects.classes.ListClass;
 import com.xpn.xwiki.objects.classes.ListItem;
 import com.xpn.xwiki.objects.classes.PropertyClass;
+import com.xpn.xwiki.objects.classes.StaticListClass;
 
 /**
  * Identifies values of DBLists of the configured class and transforms the received value in stored value. Initialized
@@ -107,6 +108,12 @@ public class DBListIdentifierPostprocessor implements RowDataPostprocessor
                             String valueToAdd = values.get(v);
                             if (StringUtils.isNotBlank(valueToAdd)) {
                                 dataToStore.add(valueToAdd);
+                            } else {
+                                // The value was not found in the values map, but it might simply be a key,
+                                // so we keep it as is.
+                                // TODO: in case the key does not exist in the available DBList keys, the user
+                                // should get warned they might be importing inconsistent data.
+                                dataToStore.add(v);
                             }
                         }
                         // TODO: should escape the list separator, somehow, or call this function once the list parsing


### PR DESCRIPTION
Just a suggestion, not sure it's the most appropriate behaviour. The idea being to be able to use two approaches for DBLists: either import DBList keys upon lookup by value, or import DBList keys as is if the lookup fails.